### PR TITLE
Fix handling WS element during comment parsing

### DIFF
--- a/lib/Perl6/Parser/Factory.pm6
+++ b/lib/Perl6/Parser/Factory.pm6
@@ -931,7 +931,7 @@ class Perl6::Parser::Factory {
 							$from - $right-margin,
 							$2.Str
 						)
-					);
+					) if $2.Str;
 				}
 				when m{ \S } {
 				}

--- a/lib/Perl6/Parser/Factory.pm6
+++ b/lib/Perl6/Parser/Factory.pm6
@@ -913,22 +913,24 @@ class Perl6::Parser::Factory {
 					);
 				}
 				when m{ ^ ( \s+ ) ( '#' .+ ) $$ ( \s* ) $ } {
-					my Int $left-margin = $0.Str.chars;
-					my Int $right-margin = $2.Str.chars;
+					my Int:D $left = $from;
+					my Int:D $center = $left + $0.Str.chars;
+					my Int:D $right = $center + $1.Str.chars;
+
 					@child.append(
 						Perl6::WS.from-int(
-							$from, $0.Str
+							$left, $0.Str
 						)
 					);
 					@child.append(
 						Perl6::Comment.from-int(
-							$left-margin + $from,
+							$center,
 							$1.Str
 						)
 					);
 					@child.append(
 						Perl6::WS.from-int(
-							$from - $right-margin,
+							$right,
 							$2.Str
 						)
 					) if $2.Str;


### PR DESCRIPTION
- Don't misplace "\n" WS element after comment
- Don't emit empty WS element after comment

See commit messages for further details