### PR TITLE
Hint at source type

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -17,7 +17,7 @@
    "perl" : "6.c",
    "build-depends" : [],
    "auth" : "github:drforr",
-   "source-url" : "https://github.com/drfor/perl6-Perl6-Parser.git",
+   "source-url" : "https://github.com/drforr/perl6-Perl6-Parser.git",
    "depends" : [
    ],
    "name" : "Perl6::Parser",

--- a/META6.json
+++ b/META6.json
@@ -17,7 +17,7 @@
    "perl" : "6.c",
    "build-depends" : [],
    "auth" : "github:drforr",
-   "source-url" : "https://github.com/drfor/perl6-Perl6-Parser",
+   "source-url" : "https://github.com/drfor/perl6-Perl6-Parser.git",
    "depends" : [
    ],
    "name" : "Perl6::Parser",


### PR DESCRIPTION
zef handles more than git repos, so it needs to be able to distinguish the source type without hard-coding host heuristics