### PR TITLE
changes to improve README appearance and get the example prog to run

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,8 @@
 		"parsing"
    ],
    "provides" : {
-      "Perl6::Parser" : "lib/Perl6/Parser.pm6"
+      "Perl6::Parser" : "lib/Perl6/Parser.pm6",
+      "Perl6::Parser::Factory" : "lib/Perl6/Parser/Factory.pm6"
    },
    "test-depends" : [
       "Test"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In a typical Perl6:: dump, here's what you'll see:
 Whitespace, semicolons and braces also belong to a generic `Structure' category
 so you can ignore those if you want to.
 
-What do all the `(...)' mean? And why are there G and WS cluttering up the
+What do all the '(...)' mean? And why are there G and WS cluttering up the
 far left side of the display? Well, I'm glad you asked.
 
     * ("use") is the actual text of the bareword, string or variable name.
@@ -146,29 +146,29 @@ your nose. YOU HAVE BEEN WARNED.
 There are two methods in L<Perl6::Parser>, and one core method that you'll find
 useful as you delve into the murky waters of the code.
 
-The first one is useful after C<$pt.parse( $source )> - You can use
-C<.dump> on the resultant object, and (usually) get a dump of the NQPMatch
+The first one is useful after ```$pt.parse( $source )``` - You can use
+```.dump``` on the resultant object, and (usually) get a dump of the NQPMatch
 object that the Perl 6 parser has generated for your source. I say "usually"
-because there are some conditions under which C<.dump> will hang, most of the
+because there are some conditions under which ```.dump``` will hang, most of the
 time because you've passed it a list element. This is an issue with the
 NQP core, and deprioritized as such.
 
-The next one is useful after C<$pt.build-tree( $p )>, and that is
-C<$pt.dump-tree( $tree )>. This gives a nicely-annotated view of the
+The next one is useful after ```$pt.build-tree( $p )```, and that is
+```$pt.dump-tree( $tree )```. This gives a nicely-annotated view of the
 L<Perl6::Parser> tree, complete with text that it's matched in gist form, and
 the start and end markers of each leaf on the tree.
 (Start and end markers for constructs like L<Perl6::Document> and
 L<Perl6::Statement> are elided because they're computed from the underlying
-C<:child> elements. My rationale for ignoring those is that when I'm
+  ```:child``` elements. My rationale for ignoring those is that when I'm
 debugging line boundaries, I'm most concerned with what I can immediately
 affect in the code; since statement and document boundaries are generated for
 me, they're not something I can/should be tweaking.
 
-Finally, there's a little C<$pt.ruler( $source )> helper. All it does is put
+Finally, there's a little ```$pt.ruler( $source )``` helper. All it does is put
 up a bit of text like so:
 
 
-``` perl6
+```
   #          1         2
   #012345678901234567890
   #unit subset Foo;␤
@@ -191,13 +191,13 @@ automatically a valid comment.
 
 ## DEVELOPER NOTES
 
-Internal classes are labeled with a leading C<_> so they will never be confused with native Perl6 classes. This is very likely with this sort of grammar, see L<_Signature> vs. the existing L<Signature> class.
+Internal classes are labeled with a leading ```_``` so they will never be confused with native Perl6 classes. This is very likely with this sort of grammar, see L<_Signature> vs. the existing L<Signature> class.
 
 At the moment, moving the 160+ separate classes out into a separate directory causes a severe run-time penalty on my VM, so they'll stay in a single file. Doing search-and-destroy on one file is easier than search-n-destroy on 160 different files, and I run less of a risk of forgetting something if the internal classes are all in one file.
 
-Classes that will be exposed to the outside world won't have the leading C<_> of course, and will have names that reflect their place in the grammar more closely.
+Classes that will be exposed to the outside world won't have the leading ```_``` of course, and will have names that reflect their place in the grammar more closely.
 
-If the flow of control inside a C<new()> or C<is-valid()> method ever gets to the end of its block, the code should simply die. Something went wrong, and it's better to get information as close to the point of failure as possible. Also once this goes into the ecosystem I want to be terribly paranoid about changes to Perl6 core code.
+If the flow of control inside a ```new()``` or ```is-valid()``` method ever gets to the end of its block, the code should simply die. Something went wrong, and it's better to get information as close to the point of failure as possible. Also once this goes into the ecosystem I want to be terribly paranoid about changes to Perl6 core code.
 
 Flow of control should never make it to the bottom of a loop block either, because one of the validators inside the loop should handle at least one of the cases.
 
@@ -205,9 +205,9 @@ Until I come up with a better scheme, validators should be ordered in descending
 
 I'm eventually going to remove all the compound classes such as L<_Atom_SigFinal> because that's where the combinatoric explosion will start to happen, and I'm already starting to see that q.v. L<_Atom_SigFinal> and L<_Atom_SigFinal_Quantifier> - Better to have just the separate L<_Atom> and L<_SigFinal> classes, and let the grammar put them together naturally.
 
-When it comes to debugging the NQP internals, one simple thing to do is not to dump the $parsed object right at the point of invocation, but look one layer up the stack and debug from inside that function. It's a happy coincidence that usually any C<Mu $parsed> argument can be C<.dump>'d cleanly.
+When it comes to debugging the NQP internals, one simple thing to do is not to dump the $parsed object right at the point of invocation, but look one layer up the stack and debug from inside that function. It's a happy coincidence that usually any ```Mu $parsed``` argument can be ```.dump```'d cleanly.
 
-It's a habit of mine, though by no means a requirement, to stuff test data into the L<t/> files with every line starting with C<###>, so that I have a simple marker to search for when I'm parsing new lines.
+It's a habit of mine, though by no means a requirement, to stuff test data into the L<t/> files with every line starting with ```###```, so that I have a simple marker to search for when I'm parsing new lines.
 
 Incidentally, L<t/rosetta-*> files are just meant to be echoes of the RosettaCode examples, not an exhaustive Christmas-tree test of the entire grammar. There doesn't appear to be an existing test of the actual parsing in the Rakudo test suite beyond "Lookie here, it can read 'hello, world!'", which is fine; If the grammar has gone south then any test suites are probably going to generate more noise than they're worth.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ PLEASE DO NOT ASSUME THIS IS STABLE OR IN ANY WAY REPRESENTATIVE OF THE FINAL
 PRODUCT. Doing so will void your warranty, and may cause demons to fly from
 your nose. YOU HAVE BEEN WARNED.
 
-** DEBUGGING UTILITIES
+## DEBUGGING UTILITIES
 
 There are two methods in L<Perl6::Parser>, and one core method that you'll find
 useful as you delve into the murky waters of the code.

--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ me, they're not something I can/should be tweaking.
 Finally, there's a little C<$pt.ruler( $source )> helper. All it does is put
 up a bit of text like so:
 
-#          1         2
-#012345678901234567890
-#unit subset Foo;␤
+
+  #          1         2
+  #012345678901234567890
+  #unit subset Foo;␤
 
 First it puts up a tiny ASCII-art ruler that helps you count characters, with
 every 10 characters called out w/an extra tick above. This way you don't go

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ your nose. YOU HAVE BEEN WARNED.
 There are two methods in L<Perl6::Parser>, and one core method that you'll find
 useful as you delve into the murky waters of the code.
 
-The first one is useful after C<$pt.parse-source( $source )> - You can use
+The first one is useful after C<$pt.parse( $source )> - You can use
 C<.dump> on the resultant object, and (usually) get a dump of the NQPMatch
 object that the Perl 6 parser has generated for your source. I say "usually"
 because there are some conditions under which C<.dump> will hang, most of the
@@ -168,7 +168,7 @@ Finally, there's a little C<$pt.ruler( $source )> helper. All it does is put
 up a bit of text like so:
 
 #          1         2
-#01234567890123456789
+#012345678901234567890
 #unit subset Foo;␤
 
 First it puts up a tiny ASCII-art ruler that helps you count characters, with
@@ -215,10 +215,10 @@ Incidentally, L<t/rosetta-*> files are just meant to be echoes of the RosettaCod
 Installation
 ============
 
-* Using panda (a module management tool bundled with Rakudo Star):
+* Using zef (a module management tool bundled with Rakudo Star):
 
 ```
-    panda update && panda install Perl6::Parser
+    zef update && zef install Perl6::Parser
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ PLEASE DO NOT ASSUME THIS IS STABLE OR IN ANY WAY REPRESENTATIVE OF THE FINAL
 PRODUCT. Doing so will void your warranty, and may cause demons to fly from
 your nose. YOU HAVE BEEN WARNED.
 
-=begin DEBUGGING UTILITIES
+** DEBUGGING UTILITIES
 
 There are two methods in L<Perl6::Parser>, and one core method that you'll find
 useful as you delve into the murky waters of the code.
@@ -168,9 +168,12 @@ Finally, there's a little C<$pt.ruler( $source )> helper. All it does is put
 up a bit of text like so:
 
 
+``` perl6
   #          1         2
   #012345678901234567890
   #unit subset Foo;␤
+
+```
 
 First it puts up a tiny ASCII-art ruler that helps you count characters, with
 every 10 characters called out w/an extra tick above. This way you don't go
@@ -186,9 +189,7 @@ And then, so you can copy the text into another buffer without worrying about
 whether it'll be accidentally run as code, adds '#' to the start so that it's
 automatically a valid comment.
 
-=end DEBUGGING UTILITIES
-
-=begin DEVELOPER NOTES
+## DEVELOPER NOTES
 
 Internal classes are labeled with a leading C<_> so they will never be confused with native Perl6 classes. This is very likely with this sort of grammar, see L<_Signature> vs. the existing L<Signature> class.
 
@@ -209,8 +210,6 @@ When it comes to debugging the NQP internals, one simple thing to do is not to d
 It's a habit of mine, though by no means a requirement, to stuff test data into the L<t/> files with every line starting with C<###>, so that I have a simple marker to search for when I'm parsing new lines.
 
 Incidentally, L<t/rosetta-*> files are just meant to be echoes of the RosettaCode examples, not an exhaustive Christmas-tree test of the entire grammar. There doesn't appear to be an existing test of the actual parsing in the Rakudo test suite beyond "Lookie here, it can read 'hello, world!'", which is fine; If the grammar has gone south then any test suites are probably going to generate more noise than they're worth.
-
-=end DEVELOPER NOTES
 
 
 Installation

--- a/examples/perl6-dumper
+++ b/examples/perl6-dumper
@@ -3,12 +3,14 @@
 use lib '../lib';
 use Perl6::Parser;
 
-sub MAIN( Str $filename ) {
+sub MAIN(Str $filename, Bool :$ruler = False) {
 	my $text = $filename.IO.slurp;
-
 	my $pt = Perl6::Parser.new;
-	my $p = $pt.parse-source( $text );
-	my $tree = $pt._build-tree( $p );
-	say "Source validated!" if $pt.validate( $p );
+	if $ruler {
+	    say $pt.ruler( $text );
+	    return;
+	}
+	my $p = $pt.parse( $text );
+	my $tree = $pt.build-tree( $p );
 	say $pt.dump-tree( $tree );
 }

--- a/examples/sample.p6
+++ b/examples/sample.p6
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl6
+
+if !@*ARGS {
+    say "Usage: $*PROGRAM-NAME go";
+    exit;
+}
+
+foo;
+
+sub foo() {
+    say "Hi from sub foo!";
+}

--- a/lib/Perl6/Parser.pm6
+++ b/lib/Perl6/Parser.pm6
@@ -131,7 +131,7 @@ And rerun your code. Or make the appropriate calls in the debugger, it's your fu
 
     45 60 [[0, $_ ... 100]]
 
-The two numbers are the glyphs where the matched text starts and stops, respectively. The bit in between [..] (in this case seemingly doubled, but that's because the text is itself bracketed) is the actual text that's been matched. 
+The two numbers are the glyphs where the matched text starts and stops, respectively. The bit in between [..] (in this case seemingly doubled, but that's because the text is itself bracketed) is the actual text that's been matched.
 
 So, by now you know what the text you're matching actually looks like, where it is in the string, and maybe eve have a rough idea of why what you're seeing isn't being displayedk
 
@@ -445,7 +445,7 @@ class Perl6::Parser {
 		$parsed;
 	}
 
-	method _build-tree( Mu $parsed ) {
+	method build-tree( Mu $parsed ) {
 		my $tree = $.factory.build( $parsed );
 		self.consistency-check( $tree ) if
 			$*CONSISTENCY-CHECK and %*ENV<AUTHOR>;


### PR DESCRIPTION
+ changed most perl 6 pod to markdown
+ added sample.p6 file in the examples dir
+ rename methods to agree with README
+ code changes to enable execution of the example file
+ added missing file to the META6.json file
+ add --ruler option to the example file
+ will change README perl 6 pod L<> later