### PR TITLE
rename build-tree in Parser.pm6

### DIFF
--- a/lib/Perl6/Parser.pm6
+++ b/lib/Perl6/Parser.pm6
@@ -507,7 +507,7 @@ class Perl6::Parser {
 
 	method to-tree( Str $source ) {
 		my $parsed = self.parse( $source );
-		self._build-tree( $parsed );
+		self.build-tree( $parsed );
 	}
 
 	method to-string( Perl6::Element $tree ) {


### PR DESCRIPTION
missed a rename in the original PR