### PR TITLE
Adapt tests for v6.d release

### DIFF
--- a/t/01-parse-text.t
+++ b/t/01-parse-text.t
@@ -20,8 +20,8 @@ subtest {
 	plan 11;
 
 	my $p = $pt.parse( Q{'a'} );
-	is-deeply [ $p.hash.keys ], [< statementlist >],
-		Q{document has correct hash keys};
+	ok $p.hash.keys.any eq ‘statementlist’,
+		Q{document has a statementlist};
 
 	my $a = $p.hash.<statementlist>;
 	is-deeply [ $a.hash.keys ], [< statement >],


### PR DESCRIPTION
Documents now have a lang-version.

https://github.com/rakudo/rakudo/commit/46ef0ea08cae96db25c7b5a9543ba696034408c8#diff-d3980092fdbde9a1dd4a30438f8dba19R1348