### PR TITLE
Adds tests for pods

### DIFF
--- a/t/21-pod.t
+++ b/t/21-pod.t
@@ -11,12 +11,36 @@ plan 1;
 my $*CONSISTENCY-CHECK = True;
 my $*FALL-THROUGH      = True;
 
+constant %tests = { "test.pod6" => /extension/,
+                    "multi.pod6" => /mortals/ };
+
+subtest {
+    my $p6p = Perl6::Parser.new;
+    for %tests.kv -> $file, $re {
+        my $prefix = $file.IO.e??"corpus/"!!"t/corpus/";
+        my $file-name = $prefix ~ $file;
+        my $pod = $file-name.IO.slurp;
+        my @pod = $p6p.to-tree($pod);
+        like( @pod[0].^name, /Perl6\:\:/, "File parses to a Pod");
+        like( @pod.gist, $re, "$file gets the content right" );
+
+    }
+}, "Files";
+
 subtest {
   ok round-trips( Q:to[_END_] ), Q{formatted};
   =begin EMPTY
   =end EMPTY
-  _END_
-  
+_END_
+
+  ok round-trips( Q:to[_END_] ), Q{formatted};
+=begin pod
+This ordinary paragraph introduces a code block:
+    $this = 1 * code('block');
+    $which.is_specified(:by<indenting>);
+=end pod
+_END_
+
   done-testing;
 }, Q{empty};
 

--- a/t/corpus/multi.pod6
+++ b/t/corpus/multi.pod6
@@ -1,0 +1,16 @@
+=begin pod
+
+Pod 6, determined heuristically.
+
+=end pod
+
+#| Base class for magicians 
+class Magician {
+  has Int $.level;
+  has Str @.spells;
+}
+ 
+#| Flight mechanics 
+sub duel(Magician $a, Magician $b) {
+}
+#= Magicians only, no mortals. 

--- a/t/corpus/test.pod6
+++ b/t/corpus/test.pod6
@@ -1,0 +1,16 @@
+=begin pod
+
+Pod 6, indicated by extension.
+
+=end pod
+
+#| Base class for magicians 
+class Magician {
+  has Int $.level;
+  has Str @.spells;
+}
+ 
+#| Flight mechanics 
+sub duel(Magician $a, Magician $b) {
+}
+#= Magicians only, no mortals. 


### PR DESCRIPTION
I was testing it to incorporate into my Pod::Load, but the main problem is that it does not seem to parse *inside* the actual Pod, it just passes it through.
In general, I would need the self-same tree that if it was parsed by Perl 6. Different names I could handle, though. Anyway, great work.