### PR TITLE
Make sure we get a compiler

### DIFF
--- a/lib/Perl6/Parser.pm6
+++ b/lib/Perl6/Parser.pm6
@@ -540,7 +540,7 @@ class Perl6::Parser:ver<0.3.0> {
 	#
 	method parse( Str $source ) {
 		my $*LINEPOSCACHE;
-		my $compiler := nqp::getcomp('perl6');
+		my $compiler := nqp::getcomp('Raku') // nqp::getcomp('perl6');
 		my $g := nqp::findmethod(
 			$compiler,'parsegrammar'
 		)($compiler);


### PR DESCRIPTION
The internal name of the language has changed from "perl6" to Raku.