### PR TITLE
Make sure creating error message doesn't die

### DIFF
--- a/lib/Perl6/Parser/Factory.pm6
+++ b/lib/Perl6/Parser/Factory.pm6
@@ -551,9 +551,8 @@ class Perl6::Element-List {
 			my %classified = classify {
 				$p.hash.{$_}.Str ?? 'with' !! 'without'
 			}, $p.hash.keys;
-			my Str @keys-with-content = @( %classified<with> );
-			my Str @keys-without-content =
-				@( %classified<without> );
+			my Str @keys-with-content =    @$_ with %classified<with>;
+			my Str @keys-without-content = @$_ with %classified<without>;
 
 			$*ERR.say( "With content: {@keys-with-content.gist}" );
 			$*ERR.say(


### PR DESCRIPTION
Trying to find out why this module doesn't test ok on 2020.01.  Found out that at least an error occurred in trying to create an extended error message.  So now at least, we can see the error as it was intended!